### PR TITLE
Guard login gamemode alignment until data exists

### DIFF
--- a/src/main/resources/assets/tquickswap/lang/de_de.json
+++ b/src/main/resources/assets/tquickswap/lang/de_de.json
@@ -62,6 +62,7 @@
   "message.tquickswap.swap_menu_hint": "Klicken, um /swap menu zu öffnen",
   "message.tquickswap.backup_auto": "TQuickSwap stellte %s-Profil aus Backup #%s wieder her",
   "message.tquickswap.backup_manual": "TQuickSwap wendete Backup #%s für %s-Profil an.",
+  "message.tquickswap.login_no_snapshot": "TQuickSwap ist installiert, hat aber noch keine gespeicherten Daten. Führe /swap einmal aus, um zu initialisieren.",
   "message.tquickswap.never": "nie",
 
   "message.tquickswap.enabled": "aktiviert",

--- a/src/main/resources/assets/tquickswap/lang/en_us.json
+++ b/src/main/resources/assets/tquickswap/lang/en_us.json
@@ -62,6 +62,7 @@
   "message.tquickswap.swap_menu_hint": "Click to open /swap menu",
   "message.tquickswap.backup_auto": "TQuickSwap restored %s profile from backup #%s",
   "message.tquickswap.backup_manual": "TQuickSwap applied backup #%s for %s profile.",
+  "message.tquickswap.login_no_snapshot": "TQuickSwap is installed but has no saved data yet; run /swap once to initialize.",
   "message.tquickswap.never": "never",
 
   "message.tquickswap.enabled": "enabled",

--- a/src/main/resources/assets/tquickswap/lang/nl_nl.json
+++ b/src/main/resources/assets/tquickswap/lang/nl_nl.json
@@ -62,6 +62,7 @@
   "message.tquickswap.swap_menu_hint": "Klik om /swap menu te openen",
   "message.tquickswap.backup_auto": "TQuickSwap heeft %s-profiel uit backup #%s hersteld",
   "message.tquickswap.backup_manual": "TQuickSwap paste backup #%s toe voor %s-profiel.",
+  "message.tquickswap.login_no_snapshot": "TQuickSwap is geïnstalleerd maar heeft nog geen opgeslagen gegevens; voer /swap één keer uit om te initialiseren.",
   "message.tquickswap.never": "nooit",
 
   "message.tquickswap.enabled": "ingeschakeld",

--- a/src/main/resources/assets/tquickswap/lang/ru_ru.json
+++ b/src/main/resources/assets/tquickswap/lang/ru_ru.json
@@ -62,6 +62,7 @@
   "message.tquickswap.swap_menu_hint": "Нажмите, чтобы открыть /swap menu",
   "message.tquickswap.backup_auto": "TQuickSwap восстановил профиль %s из резерва #%s",
   "message.tquickswap.backup_manual": "TQuickSwap применил резерв #%s для профиля %s.",
+  "message.tquickswap.login_no_snapshot": "TQuickSwap установлен, но сохранения ещё не созданы. Выполните /swap для инициализации.",
   "message.tquickswap.never": "никогда",
 
   "message.tquickswap.enabled": "включено",

--- a/src/main/resources/assets/tquickswap/lang/zh_cn.json
+++ b/src/main/resources/assets/tquickswap/lang/zh_cn.json
@@ -62,6 +62,7 @@
   "message.tquickswap.swap_menu_hint": "点击打开 /swap menu",
   "message.tquickswap.backup_auto": "TQuickSwap 从备份 #%s 恢复了 %s 档案",
   "message.tquickswap.backup_manual": "TQuickSwap 已将备份 #%s 应用于 %s 档案。",
+  "message.tquickswap.login_no_snapshot": "TQuickSwap 已安装但尚无保存数据，请执行 /swap 进行初始化。",
   "message.tquickswap.never": "从未",
 
   "message.tquickswap.enabled": "已启用",


### PR DESCRIPTION
## Summary
- only align player gamemodes on login when stored profile data was restored and explain the guard inline
- notify players when login gamemode alignment is skipped due to missing data and localize the new message in bundled languages

## Testing
- ./gradlew build *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68e3bdd0de9c832ebacd0453cb6ce662